### PR TITLE
Update to Gradle 7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,26 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.diffplug.gradle:goomph:3.29.1'
     }
 }
 
 allprojects {
     buildscript {
         repositories {
-            jcenter()
+            mavenCentral()
         }
     }
 
     group = 'io.mx51'
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -25,19 +25,19 @@ ext {
 }
 
 dependencies {
-    compile 'commons-lang:commons-lang:2.6'
-    compile 'commons-codec:commons-codec:1.11'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.squareup.okhttp3:okhttp:3.12.3'
-    compile 'org.slf4j:slf4j-api:1.7.25'
-    compile 'org.jetbrains:annotations:16.0.1'
+    implementation 'commons-lang:commons-lang:2.6'
+    implementation 'commons-codec:commons-codec:1.11'
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.3'
+    implementation 'org.slf4j:slf4j-api:1.7.25'
+    implementation 'org.jetbrains:annotations:16.0.1'
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 sourceSets.main.java.srcDirs += 'src/gen/java'
 
-distributions.main.baseName = archivesBaseName
+distributions.main.distributionBaseName = archivesBaseName
 
 apply from: '../gradle/publish.gradle'
 apply from: '../gradle/config.gradle'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,18 +1,16 @@
 // See: https://central.sonatype.org/publish/publish-gradle/
 
-apply plugin: 'osgi'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'com.diffplug.osgi.bndmanifest'
 
-jar {
-    manifest {
-        instruction 'Bundle-Description', project.publishName
-        instruction 'Bundle-Vendor', project.publishVendor
-        instruction 'Implementation-Title', project.publishName
-        instruction 'Implementation-Vendor', project.publishVendor
-        instruction 'Implementation-Version', project.version
-    }
-}
+jar.manifest.attributes(
+        'Bundle-Description': project.publishName,
+        'Bundle-Vendor': project.publishVendor,
+        'Implementation-Title': project.publishName,
+        'Implementation-Vendor': project.publishVendor,
+        'Implementation-Version': project.version
+)
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -15,6 +15,6 @@ run {
 }
 
 dependencies {
-    compile project(':client')
-    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.10.0'
+    implementation project(':client')
+    implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.10.0'
 }


### PR DESCRIPTION
To automate closing/releasing Sonatype repository, you will need to integrate [publish-plugin](https://github.com/gradle-nexus/publish-plugin/) (I recommend [this guide](https://dev.to/madhead/no-bullshit-guide-on-publishing-your-gradle-projects-to-maven-central-3ok4) in addition to official docs), but it requires Gradle 5.0 minimum and this repository is stuck with 4.8.1. This PR upgrades the project to the latest 7.0 (released last week) and fixes all deprecations.

Other than some parameter renames, Gradle 5+ removed the built-in OSGi plugin. To rectify that, I replaced it with [com.diffplug.osgi.bndmanifest](https://plugins.gradle.org/plugin/com.diffplug.osgi.bndmanifest), which does the same thing. OSGi adds useful information to META-INF/MANIFEST.MF like Implementation-Version, to help identify the library version when integration partner drops it in manually without using Maven's dependency management.